### PR TITLE
refactor: Pull in latest proto changes

### DIFF
--- a/.idea/.idea.OddDotCSharp/.idea/vcs.xml
+++ b/.idea/.idea.OddDotCSharp/.idea/vcs.xml
@@ -2,5 +2,6 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
+    <mapping directory="$PROJECT_DIR$/src/OddDotCSharp/OddDotProto" vcs="Git" />
   </component>
 </project>

--- a/src/OddDotCSharp/SpanQueryRequestBuilder.cs
+++ b/src/OddDotCSharp/SpanQueryRequestBuilder.cs
@@ -9,7 +9,7 @@ namespace OddDotCSharp
     /// </summary>
     public class SpanQueryRequestBuilder
     {
-        private const ulong DefaultDurationMilliseconds = 30000;
+        private const int DefaultDurationMilliseconds = 30000;
         
         private readonly SpanQueryRequest _request;
         private readonly WhereSpanFilterConfigurator _whereSpanFilterConfigurator;
@@ -32,7 +32,7 @@ namespace OddDotCSharp
                 },
                 Duration = new Duration
                 {
-                    MillisecondsValue = DefaultDurationMilliseconds
+                    Milliseconds = DefaultDurationMilliseconds
                 }
             };
             
@@ -79,7 +79,7 @@ namespace OddDotCSharp
         {
             _request.Duration = new Duration
             {
-                MillisecondsValue = (ulong)duration.TotalMilliseconds // TODO change to int, ulong ms is way too long
+                Milliseconds = (int)duration.TotalMilliseconds
             };
             return this;
         }

--- a/src/OddDotCSharp/SpanQueryRequestBuilder.cs
+++ b/src/OddDotCSharp/SpanQueryRequestBuilder.cs
@@ -73,13 +73,17 @@ namespace OddDotCSharp
         /// <summary>
         /// Allows for specifying the amount of time to wait for a matching Span to be received. 
         /// </summary>
-        /// <param name="duration">The TimeSpan specifying how long to wait for Spans.</param>
+        /// <param name="timeSpan">
+        /// The TimeSpan specifying how long to wait for Spans. Negative values will result in a Duration of 0.
+        /// </param>
         /// <returns>this <see cref="SpanQueryRequestBuilder"/></returns>
-        public SpanQueryRequestBuilder Wait(TimeSpan duration)
+        public SpanQueryRequestBuilder Wait(TimeSpan timeSpan)
         {
+            int duration = timeSpan.TotalMilliseconds < 0 ? 0 : (int)timeSpan.TotalMilliseconds;
+                
             _request.Duration = new Duration
             {
-                Milliseconds = (int)duration.TotalMilliseconds
+                Milliseconds = duration
             };
             return this;
         }

--- a/tests/OddDotCSharp.Tests/SpanQueryRequestBuilderTests.cs
+++ b/tests/OddDotCSharp.Tests/SpanQueryRequestBuilderTests.cs
@@ -17,11 +17,10 @@ public class SpanQueryRequestBuilderTests
         [Fact]
         public void SetDurationToDefaultWhenNotSpecified()
         {
-            ulong expectedMsValue = 30000;
+            int expectedMsValue = 30000;
             var request = new SpanQueryRequestBuilder().Build();
             
-            Assert.Equal(Duration.ValueOneofCase.MillisecondsValue, request.Duration.ValueCase);
-            Assert.Equal(expectedMsValue, request.Duration.MillisecondsValue);
+            Assert.Equal(expectedMsValue, request.Duration.Milliseconds);
         }
     }
 
@@ -76,8 +75,7 @@ public class SpanQueryRequestBuilderTests
             builder.Wait(duration);
             var request = builder.Build();
             
-            Assert.Equal(Duration.ValueOneofCase.MillisecondsValue, request.Duration.ValueCase);
-            Assert.Equal(duration.TotalMilliseconds, request.Duration.MillisecondsValue);
+            Assert.Equal(duration.TotalMilliseconds, request.Duration.Milliseconds);
         }
     }
 


### PR DESCRIPTION
The latest proto changes have seconds and minutes removed from duration. Now it's just milliseconds.