### PR TITLE
docs: correct query wait contract in QueryRequest builders

### DIFF
--- a/src/OddDotCSharp/Proto/Logs/V1/LogQueryRequestBuilder.cs
+++ b/src/OddDotCSharp/Proto/Logs/V1/LogQueryRequestBuilder.cs
@@ -51,7 +51,8 @@ namespace OddDotCSharp
         }
         
         /// <summary>
-        /// Takes the first Log that it matches against.
+        /// Configures the query to return as soon as the first matching Log is found, or when
+        /// the Wait duration elapses if none is found. This is the default.
         /// </summary>
         /// <returns>this <see cref="LogQueryRequestBuilder"/></returns>
         public LogQueryRequestBuilder TakeFirst()
@@ -61,7 +62,8 @@ namespace OddDotCSharp
         }
         
         /// <summary>
-        /// Takes the exact number of Logs specified that it matches against.
+        /// Configures the query to return as soon as <paramref name="count"/> matching Logs are
+        /// found, or when the Wait duration elapses with fewer than <paramref name="count"/> found.
         /// </summary>
         /// <param name="count">The number of Logs to find.</param>
         /// <returns>this <see cref="LogQueryRequestBuilder"/></returns>
@@ -72,7 +74,10 @@ namespace OddDotCSharp
         }
         
         /// <summary>
-        /// Takes all Logs that match the given filters within the provided timeframe.
+        /// Configures the query to collect every matching Log seen over the whole Wait duration.
+        /// TakeAll never returns early — the query always blocks for the full duration — so prefer
+        /// <see cref="TakeFirst"/> or <see cref="TakeExact"/> with a filter to return as soon as a
+        /// specific Log arrives.
         /// </summary>
         /// <returns>this <see cref="LogQueryRequestBuilder"/></returns>
         public LogQueryRequestBuilder TakeAll()
@@ -82,10 +87,12 @@ namespace OddDotCSharp
         }
         
         /// <summary>
-        /// Allows for specifying the amount of time to wait for a matching Log to be received. 
+        /// Sets the maximum time the query blocks for matching Logs. A value of zero or less
+        /// selects the sink default of 30 seconds; it does not return immediately.
         /// </summary>
         /// <param name="timeSpan">
-        /// The TimeSpan specifying how long to wait for Logs. Negative values will result in a Duration of 0.
+        /// The maximum time to wait for Logs. Zero or negative produces a Duration of 0, which the
+        /// sink treats as its 30-second default.
         /// </param>
         /// <returns>this <see cref="LogQueryRequestBuilder"/></returns>
         public LogQueryRequestBuilder Wait(TimeSpan timeSpan)

--- a/src/OddDotCSharp/Proto/Metrics/V1/MetricQueryRequestBuilder.cs
+++ b/src/OddDotCSharp/Proto/Metrics/V1/MetricQueryRequestBuilder.cs
@@ -51,7 +51,8 @@ namespace OddDotCSharp
         }
         
         /// <summary>
-        /// Takes the first Metric that it matches against.
+        /// Configures the query to return as soon as the first matching Metric is found, or when
+        /// the Wait duration elapses if none is found. This is the default.
         /// </summary>
         /// <returns>this <see cref="MetricQueryRequestBuilder"/></returns>
         public MetricQueryRequestBuilder TakeFirst()
@@ -61,7 +62,8 @@ namespace OddDotCSharp
         }
         
         /// <summary>
-        /// Takes the exact number of Metrics specified that it matches against.
+        /// Configures the query to return as soon as <paramref name="count"/> matching Metrics are
+        /// found, or when the Wait duration elapses with fewer than <paramref name="count"/> found.
         /// </summary>
         /// <param name="count">The number of Metrics to find.</param>
         /// <returns>this <see cref="MetricQueryRequestBuilder"/></returns>
@@ -72,7 +74,10 @@ namespace OddDotCSharp
         }
         
         /// <summary>
-        /// Takes all Metrics that match the given filters within the provided timeframe.
+        /// Configures the query to collect every matching Metric seen over the whole Wait duration.
+        /// TakeAll never returns early — the query always blocks for the full duration — so prefer
+        /// <see cref="TakeFirst"/> or <see cref="TakeExact"/> with a filter to return as soon as a
+        /// specific Metric arrives.
         /// </summary>
         /// <returns>this <see cref="MetricQueryRequestBuilder"/></returns>
         public MetricQueryRequestBuilder TakeAll()
@@ -82,10 +87,12 @@ namespace OddDotCSharp
         }
         
         /// <summary>
-        /// Allows for specifying the amount of time to wait for a matching Metric to be received. 
+        /// Sets the maximum time the query blocks for matching Metrics. A value of zero or less
+        /// selects the sink default of 30 seconds; it does not return immediately.
         /// </summary>
         /// <param name="timeSpan">
-        /// The TimeSpan specifying how long to wait for Metrics. Negative values will result in a Duration of 0.
+        /// The maximum time to wait for Metrics. Zero or negative produces a Duration of 0, which the
+        /// sink treats as its 30-second default.
         /// </param>
         /// <returns>this <see cref="MetricQueryRequestBuilder"/></returns>
         public MetricQueryRequestBuilder Wait(TimeSpan timeSpan)

--- a/src/OddDotCSharp/Proto/Trace/V1/SpanQueryRequestBuilder.cs
+++ b/src/OddDotCSharp/Proto/Trace/V1/SpanQueryRequestBuilder.cs
@@ -41,7 +41,8 @@ namespace OddDotCSharp
         }
 
         /// <summary>
-        /// Takes the first Span that it matches against.
+        /// Configures the query to return as soon as the first matching Span is found, or when
+        /// the Wait duration elapses if none is found. This is the default.
         /// </summary>
         /// <returns>this <see cref="SpanQueryRequestBuilder"/></returns>
         public SpanQueryRequestBuilder TakeFirst()
@@ -51,7 +52,8 @@ namespace OddDotCSharp
         }
 
         /// <summary>
-        /// Takes the exact number of Spans specified that it matches against.
+        /// Configures the query to return as soon as <paramref name="count"/> matching Spans are
+        /// found, or when the Wait duration elapses with fewer than <paramref name="count"/> found.
         /// </summary>
         /// <param name="count">The number of Spans to find.</param>
         /// <returns>this <see cref="SpanQueryRequestBuilder"/></returns>
@@ -62,7 +64,10 @@ namespace OddDotCSharp
         }
 
         /// <summary>
-        /// Takes all Spans that match the given filters within the provided timeframe.
+        /// Configures the query to collect every matching Span seen over the whole Wait duration.
+        /// TakeAll never returns early — the query always blocks for the full duration — so prefer
+        /// <see cref="TakeFirst"/> or <see cref="TakeExact"/> with a filter to return as soon as a
+        /// specific Span arrives.
         /// </summary>
         /// <returns>this <see cref="SpanQueryRequestBuilder"/></returns>
         public SpanQueryRequestBuilder TakeAll()
@@ -72,10 +77,12 @@ namespace OddDotCSharp
         }
 
         /// <summary>
-        /// Allows for specifying the amount of time to wait for a matching Span to be received. 
+        /// Sets the maximum time the query blocks for matching Spans. A value of zero or less
+        /// selects the sink default of 30 seconds; it does not return immediately.
         /// </summary>
         /// <param name="timeSpan">
-        /// The TimeSpan specifying how long to wait for Spans. Negative values will result in a Duration of 0.
+        /// The maximum time to wait for Spans. Zero or negative produces a Duration of 0, which the
+        /// sink treats as its 30-second default.
         /// </param>
         /// <returns>this <see cref="SpanQueryRequestBuilder"/></returns>
         public SpanQueryRequestBuilder Wait(TimeSpan timeSpan)


### PR DESCRIPTION
## Summary

Brings the C# `QueryRequestBuilder` XML docs in line with the verified query **wait contract**. The builders described `Take`/`Wait` loosely — `TakeAll` read as "take all within the timeframe" (no hint it never returns early), and `Wait` didn't mention that a zero/unset duration is the sink's 30s default — which made the long-poll easy to misuse.

## Changes

XML-doc updates on `TakeFirst` / `TakeExact` / `TakeAll` / `Wait` across the **span**, **log**, and **metric** builders:

- `TakeFirst` / `TakeExact` — state that they return as soon as the match count is reached, else at the Wait duration.
- `TakeAll` — call out that it **never returns early** (always blocks the full Wait), and point to `TakeFirst`/`TakeExact` + a filter for "wait for a specific signal".
- `Wait` — a value of zero or less selects the sink's **30s default**, not an immediate return.

## Verified against the server

Confirmed in `OddDotNet/SignalList.cs` (`GetTakeCount` + the `QueryAsync` loop): `TakeFirst`→1, `TakeExact`→n, `TakeAll`→`int.MaxValue` (count never reached → always waits the full `Duration`), and `Duration <= 0` → 30s default.

## Notes

- Comment-only; no code change. `dotnet build` green.
- The generated proto types (compiled at build time via Grpc.Tools) pick up the matching schema comments on the next OddDotProto submodule bump.
- Companion to OddDotNet/OddDotProto#25 and OddDotNet/OddDotGo#4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J2rAdqyGkWmhGLcfrRYxFy
